### PR TITLE
fix: module not found in __init__.py

### DIFF
--- a/HierMat/__init__.py
+++ b/HierMat/__init__.py
@@ -1,10 +1,10 @@
-from block_cluster_tree import BlockClusterTree, build_block_cluster_tree
-from cluster import Cluster
-from cluster_tree import ClusterTree, build_cluster_tree, admissible
-from cuboid import Cuboid
-from grid import Grid
-from hmat import HMat, build_hmatrix
-from rmat import RMat
-from splitable import RegularCuboid, MinimalCuboid, Balanced, Splitable
-from utils import plot, export, load, divisor_generator
-from examples.model_1d import model_1d
+from .block_cluster_tree import BlockClusterTree, build_block_cluster_tree
+from .cluster import Cluster
+from .cluster_tree import ClusterTree, build_cluster_tree, admissible
+from .cuboid import Cuboid
+from .grid import Grid
+from .hmat import HMat, build_hmatrix
+from .rmat import RMat
+from .splitable import RegularCuboid, MinimalCuboid, Balanced, Splitable
+from .utils import plot, export, load, divisor_generator
+from .examples.model_1d import model_1d


### PR DESCRIPTION
For Linux, without `.` in `__init__.py` installed in `\usr\lib` will cause:

```bash
Traceback (most recent call last):
  File "/usr/lib/python/site-packages/HierMat/__init__.py", line 1, in <module>
    from block_cluster_tree import BlockClusterTree, build_block_cluster_tree
ModuleNotFoundError: No module named 'block_cluster_tree'
```